### PR TITLE
Don't use predictable names for temporary files

### DIFF
--- a/lib/IPTables/Parse.pm
+++ b/lib/IPTables/Parse.pm
@@ -17,6 +17,7 @@ package IPTables::Parse;
 use 5.006;
 use POSIX ":sys_wait_h";
 use Carp;
+use File::Temp;
 use strict;
 use warnings;
 use vars qw($VERSION);
@@ -36,8 +37,8 @@ sub new() {
         _firewall_cmd    => $args{'firewall-cmd'} || '',
         _fwd_args        => $args{'fwd_args'}     || '--direct --passthrough ipv4',
         _ipv6            => $args{'use_ipv6'}     || 0,
-        _iptout          => $args{'iptout'}       || '/tmp/ipt.out' . $$,
-        _ipterr          => $args{'ipterr'}       || '/tmp/ipt.err' . $$,
+        _iptout          => $args{'iptout'}       || mktemp('/tmp/ipt.out.XXXXXX'),
+        _ipterr          => $args{'ipterr'}       || mktemp('/tmp/ipt.err.XXXXXX'),
         _ipt_alarm       => $args{'ipt_alarm'}    || 30,
         _debug           => $args{'debug'}        || 0,
         _verbose         => $args{'verbose'}      || 0,
@@ -980,8 +981,6 @@ IPTables::Parse - Perl extension for parsing iptables and ip6tables policies
       'use_ipv6' => 0,         # can set to 1 to force ip6tables usage
       'ipt_rules_file' => '',  # optional file path from
                                # which to read iptables rules
-      'iptout'   => '/tmp/iptables.out',
-      'ipterr'   => '/tmp/iptables.err',
       'debug'    => 0,
       'verbose'  => 0
   );


### PR DESCRIPTION
This is a security vulnerability: it allows an attacker on a multi-user system to set up symlinks to overwrite any file the current user has write access to.

Don't recommend users of this module to use predictable names either.

*Note*: I am not a perl programmer; this seems broadly the right thing and is syntactically correct, but that’s all the testing I have done.