### PR TITLE
Allow optional matching of -- in ip6tables output

### DIFF
--- a/lib/IPTables/Parse.pm
+++ b/lib/IPTables/Parse.pm
@@ -803,7 +803,7 @@ sub default_log() {
             if ($self->{'_ipt_bin_name'} eq 'ip6tables'
                     or ($self->{'_ipt_bin_name'} eq 'firewall-cmd'
                     and $self->{'_fwd_args'} =~ /\sipv6/)) {
-                if ($line =~ m|^\s*\d+\s+\d+\s*U?LOG\s+(\w+)\s+
+                if ($line =~ m|^\s*\d+\s+\d+\s*U?LOG\s+(\w+)\s+(?:\-\-\s+)?
                         \S+\s+\S+\s+$any_ip_re
                         \s+$any_ip_re\s+.*U?LOG|x) {
                     $proto = $1;
@@ -821,7 +821,7 @@ sub default_log() {
             if ($self->{'_ipt_bin_name'} eq 'ip6tables'
                     or ($self->{'_ipt_bin_name'} eq 'firewall-cmd'
                     and $self->{'_fwd_args'} =~ /\sipv6/)) {
-                if ($line =~ m|^\s*U?LOG\s+(\w+)\s+$any_ip_re
+                if ($line =~ m|^\s*U?LOG\s+(\w+)\s+(:?\-\-\s+)?$any_ip_re
                         \s+$any_ip_re\s+.*U?LOG|x) {
                     $proto = $1;
                     $found = 1;


### PR DESCRIPTION
The output format of ip6tables changed in 2021, and now ip6tables output is similar to iptables output, where `--` can be emitted in the `opt` column.

Example:
```
$ sudo /usr/sbin/ip6tables -w -t filter -n -L INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
LOG        0    --  ::/0                 ::/0                 LOG flags 2 level 4 prefix "[IPTABLES] "
```

This is the issue I was experiencing in https://github.com/mrash/IPTables-Parse/issues/9.

There's other regexes that should be updated, I think, but a) this fixes the issue for me and b) I'm entirely new to psad, iptables, and Perl so without some way to test the path I'm touching, I'm a bit hesitant to make any changes without guidance. Would gladly welcome suggestions here. :)

Anyways, to test this change, I:
- ran `psad --fw-analyze`, got a parsing error, and the usual `You may just need to add a default logging rule to the 'filter' 'INPUT' chain` email
- copied my changes into my installed copy of this module
  - for me this was at `/usr/share/perl5/IPTables/Parse.pm`
- re-ran `psad --fw-analyze`, got a successful output

```
[+] Parsing INPUT chain rules.
[+] Parsing INPUT chain rules.
[+] Parsing FORWARD chain rules.
[+] Firewall config looks good.
[+] Completed check of firewall ruleset.
[+] Results in /var/log/psad/fw_check
[+] Exiting.
```